### PR TITLE
Tap to add annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Easily create a map screen, complete with annotations.
 class MyMapScreen < PM::MapScreen
   title "My Map"
   start_position latitude: 35.090648651123, longitude: -82.965972900391, radius: 4
+  tap_to_add
 
   def annotation_data
     [{
@@ -230,6 +231,75 @@ end
 ```
 
 `radius` is the zoom level of the map in miles (default: 10).
+
+#### tap_to_add(length: Float, target: Object, action: Selector, annotation: Hash)
+
+Lets a user long press the map to drop an annotation where they pressed.
+
+##### Default values:
+
+You can override any of these values. The `annotation` parameter can take any options specified in the annotation documentation above except `:latitude`, `:longitude`, and `:coordinate`.
+
+```ruby
+length: 2.0,
+target: self,
+action: "gesture_drop_pin:",
+annotation: {
+  title: "Dropped Pin",
+  animates_drop: true
+}
+```
+
+##### Notifications
+
+This feature posts two different `NSNotificationCenter` notifications:
+
+**ProMotionMapWillAddPin:** Fired the moment the long press gesture is recognized, before the pin is added.
+
+**ProMotionMapAddedPin:** Fired after the pin has been added to the map.
+
+##### Example:
+
+```ruby
+# Simple Example
+class MyMapScreen < PM::MapScreen
+  title "My Map Screen"
+  tap_to_add length: 1.5
+  def annotations
+    []
+  end
+end
+```
+
+```ruby
+# A More Complex Example
+class MyMapScreen < PM::MapScreen
+  title "My Map Screen"
+  tap_to_add length: 1.5, annotation: {animates_drop: true, title: "A Cool New Pin"}
+  def annotations
+    []
+  end
+
+  def will_appear
+    NSNotificationCenter.defaultCenter.addObserver(self, selector:"pin_adding:") , name:"ProMotionMapWillAddPin", object:nil)
+    NSNotificationCenter.defaultCenter.addObserver(self, selector:"pin_added:") , name:"ProMotionMapAddedPin", object:nil)
+  end
+
+  def will_disappear
+    NSNotificationCenter.defaultCenter.removeObserver(self)
+  end
+
+  def pin_adding(notification)
+    # We only want one pin on the map at a time
+    clear_annotations
+  end
+
+  def pin_added(notification)
+    # Once the pin is dropped we want to select it
+    select_annotation_at(0)
+  end
+end
+```
 
 ---
 

--- a/app/test_screens/test_map_screen.rb
+++ b/app/test_screens/test_map_screen.rb
@@ -3,6 +3,7 @@ class TestMapScreen < PM::MapScreen
 
   start_position latitude: 35.090648651123, longitude: -82.965972900391, radius: 4
   title "Gorges State Park, NC"
+  tap_to_add length: 1.5, annotation: {animates_drop: false, title: "A new park?"}
 
   def on_load
     @action_called = false

--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -162,8 +162,8 @@ module ProMotion
 
     def set_start_position(params={})
       params = {
-        latitude: 37.331789
-        longitude: -122.029620
+        latitude: 37.331789,
+        longitude: -122.029620,
         radius: 10
       }.merge(params)
 

--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -161,9 +161,11 @@ module ProMotion
     end
 
     def set_start_position(params={})
-      params[:latitude] ||= 37.331789
-      params[:longitude] ||= -122.029620
-      params[:radius] ||= 10
+      params = {
+        latitude: 37.331789
+        longitude: -122.029620
+        radius: 10
+      }.merge(params)
 
       meters_per_mile = 1609.344
 
@@ -354,7 +356,6 @@ module ProMotion
       @location_manager.delegate ||= self
       @location_manager
     end
-
 
   end
 end

--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -179,13 +179,16 @@ module ProMotion
     end
 
     def set_tap_to_add(params={})
-      params[:length] ||= 2.0
-      params[:target] ||= self
-      params[:action] ||= "gesture_drop_pin:"
-      @tap_to_add_annotation_params = (params[:annotation] || {}).merge({
+      params = {
+        length: 2.0,
+        target: self,
+        action: "gesture_drop_pin:"
+      }.merge(params)
+
+      @tap_to_add_annotation_params = {
         title: "Dropped Pin",
         animates_drop: true
-      })
+      }.merge(params[:annotation] || {})
 
       lpgr = UILongPressGestureRecognizer.alloc.initWithTarget(params[:target], action:params[:action])
       lpgr.minimumPressDuration = params[:length]

--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -184,13 +184,13 @@ module ProMotion
       params = {
         length: 2.0,
         target: self,
-        action: "gesture_drop_pin:"
+        action: "gesture_drop_pin:",
+        annotation: {
+          title: "Dropped Pin",
+          animates_drop: true
+        }
       }.merge(params)
-
-      @tap_to_add_annotation_params = {
-        title: "Dropped Pin",
-        animates_drop: true
-      }.merge(params[:annotation] || {})
+      @tap_to_add_annotation_params = params[:annotation]
 
       lpgr = UILongPressGestureRecognizer.alloc.initWithTarget(params[:target], action:params[:action])
       lpgr.minimumPressDuration = params[:length]

--- a/spec/func_map_screen_spec.rb
+++ b/spec/func_map_screen_spec.rb
@@ -35,7 +35,7 @@ describe "ProMotion::TestMapScreen functionality" do
     map_screen.navigationController.should.be.kind_of(UINavigationController)
   end
 
-  it "should have the map properly centered" do
+  it "should start the map in the correct location" do
     center_coordinate = map_screen.center
     center_coordinate.latitude.should.be.close 35.090648651123, 0.02
     center_coordinate.longitude.should.be.close -82.965972900391, 0.02


### PR DESCRIPTION
Unfortunately, there's no way to test this right now other than functional testing and it can't be automated. I have a bug report out to HipByte to see if they can add long press gestures to the specs.

Example usage is in the readme.